### PR TITLE
Fix for track skipping not working

### DIFF
--- a/data/hidecloud.js
+++ b/data/hidecloud.js
@@ -185,7 +185,7 @@ if (jQuery) {
 	var playingObserver = new MutationObserver(function(mutations) {
 		mutations.forEach(function(mutation) {
 
-			trackInfo.element = document.querySelector('.playbackSoundBadge__title');
+			trackInfo.element = document.querySelector('.playbackSoundBadge__titleLink');
 
 			// Only check hidden tracks if songTitle is a descendant
 			// of the mutation target element.


### PR DESCRIPTION
Apparently since early this week track skipping would not work anymore as in hidden tracks were not skipped. Also when playing a song and hiding it, the track would continue to play.

This change apparently fixes everything but I know nothing about html or jquery so it might not be right.

Hope this helps.